### PR TITLE
[NO-ISSUE] Fix java runtime issue in ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,12 @@ jobs:
           cekit --verbose build --dry-run --overrides "{'labels': [{'name': 'quay.expires-after', 'value': '90d'}, {'name': 'git-sha', 'value': '$GITHUB_SHA'}]}" podman
           podman build --platform linux/amd64 --platform linux/arm64 --manifest $IMAGE_NAME:dev.latest ./target/image
 
+      - name: Set up java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
       - name: Check the image
         run: |
           CONTAINER_ID=$(podman run --detach --network=host --env AMQ_USER=admin --env AMQ_PASSWORD=admin $IMAGE_NAME:dev.latest)


### PR DESCRIPTION
The artemis image is now compiled with jdk17. In ci workflow the java env is still java 11 (class version 55)
Need to setup java to support java 17 runtime